### PR TITLE
farmed tokens swap improvement

### DIFF
--- a/contracts/Converter.sol
+++ b/contracts/Converter.sol
@@ -53,7 +53,7 @@ contract Converter is IConverter, Ownable {
         return bpool;
     }
 
-    function getMinMountIn() external view returns (uint256) {
+    function getMinAmountIn() external view returns (uint256) {
         return minAmountIn;
     }
 
@@ -133,5 +133,17 @@ contract Converter is IConverter, Ownable {
 
     function sweep(address _token) external onlyOwner {
         IERC20(_token).safeTransfer(owner(), IERC20(_token).balanceOf(address(this)));
+    }
+
+    function setUniswap(address _uniswap) external onlyOwner {
+        uniswap = _uniswap;
+    }
+
+    function setBPool(address _bpool) external onlyOwner {
+        bpool = _bpool;
+    }
+
+    function setMinAmountIn(uint256 _minAmountIn) external onlyOwner {
+        minAmountIn = _minAmountIn;
     }
 }

--- a/contracts/Converter.sol
+++ b/contracts/Converter.sol
@@ -85,6 +85,7 @@ contract Converter is IConverter, Ownable {
             // Return immediately in the case assetOut WETH
             // Otw swap with the default method
             if (assetOut == weth) {
+                IERC20(weth).safeTransfer(to, convertedAmount);
                 return convertedAmount;
             }
 
@@ -99,7 +100,7 @@ contract Converter is IConverter, Ownable {
         }
 
         uint[] memory amounts = IUniswapRouter(uniswap).swapExactTokensForTokens(
-            amountIn, amountOutMin, _getPath(assetIn, assetOut), msg.sender, now.add(1800)
+            amountIn, amountOutMin, _getPath(assetIn, assetOut), to, now.add(1800)
         );
 
         convertedAmount = amounts[amounts.length.sub(1)];

--- a/contracts/Converter.sol
+++ b/contracts/Converter.sol
@@ -26,7 +26,7 @@ contract Converter is IConverter, Ownable {
     using SafeMath for uint256;
 
     address internal uniswap;
-    address immutable weth;
+    address immutable public weth;
     address internal bpool;
     address internal idle;
     uint256 internal minAmountIn;

--- a/contracts/Converter.sol
+++ b/contracts/Converter.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0
+// Feel free to change the license, but this is what we use
+
+// Feel free to change this version of Solidity. We support >=0.6.0 <0.7.0;
+pragma solidity 0.6.12;
+
+import {
+    SafeERC20,
+    SafeMath,
+    Address
+} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+import "../interfaces/Uniswap/IUniswapRouter.sol";
+
+import "../interfaces/IConverter.sol";
+
+contract Converter is IConverter, Ownable {
+    using SafeERC20 for IERC20;
+    using Address for address;
+    using SafeMath for uint256;
+
+    address internal uniswap;
+    address immutable weth;
+
+    constructor(
+        address _uniswap,
+        address _weth
+    ) public {
+        uniswap = _uniswap;
+        weth = _weth;
+    }
+
+    function getUniswap() external view returns (address) {
+        return uniswap;
+    }
+
+    function convert(
+        uint amountIn,
+        uint amountOutMin,
+        address assetIn,
+        address assetOut,
+        address to
+    ) external override returns (uint convertedAmount) {
+        IERC20(assetIn).safeTransferFrom(msg.sender, address(this), amountIn);
+
+        if (IERC20(assetIn).allowance(address(this), uniswap) < amountIn) {
+            IERC20(assetIn).safeApprove(uniswap, type(uint256).max);
+        }
+
+        uint[] memory amounts = IUniswapRouter(uniswap).swapExactTokensForTokens(
+            amountIn, amountOutMin, _getPath(assetIn, assetOut), msg.sender, now.add(1800)
+        );
+
+        convertedAmount = amounts[amounts.length.sub(1)];
+    }
+
+    function _getPath(address assetIn, address assetOut) internal view returns (address[] memory path) {
+        if (assetIn == weth || assetOut == weth) {
+            path = new address[](2);
+            path[0] = assetIn;
+            path[1] = assetOut;
+        } else {
+            path = new address[](3);
+            path[0] = assetIn;
+            path[1] = weth;
+            path[2] = assetOut;
+        }
+    }
+
+    function getAmountOut(uint256 amountIn, address assetIn, address assetOut) external override view returns (uint256 amountOut) {
+        address[] memory path = _getPath(assetIn, assetOut);
+        uint256[] memory amounts = IUniswapRouter(uniswap).getAmountsOut(amountIn, path);
+        return amounts[path.length.sub(1)];
+    }
+
+    function getAmountIn(uint256 amountOut, address assetIn, address assetOut) external override view returns (uint256 amountIn) {
+        address[] memory path = _getPath(assetIn, assetOut);
+        uint256[] memory amounts = IUniswapRouter(uniswap).getAmountsIn(amountIn, path);
+        return amounts[0];
+    }
+
+    function sweep(address _token) external onlyOwner {
+        IERC20(_token).safeTransfer(owner(), IERC20(_token).balanceOf(address(this)));
+    }
+}

--- a/contracts/StrategyIdle.sol
+++ b/contracts/StrategyIdle.sol
@@ -441,7 +441,7 @@ contract StrategyIdle is BaseStrategyInitializable {
         return converter;
     }
 
-    function setConverter(address _converter) external onlyGovernanceOrManagement {
+    function setConverter(address _converter) external onlyGovernance {
         // Disallow old converter and allow new ones
         for (uint256 i = 0; i < govTokens.length; i++) {
             address govTokenAddress = govTokens[i];

--- a/contracts/StrategyIdle.sol
+++ b/contracts/StrategyIdle.sol
@@ -445,6 +445,18 @@ contract StrategyIdle is BaseStrategyInitializable {
         return converter;
     }
 
+    function setConverter(address _converter) external onlyGovernanceOrManagement {
+        // Disallow old converter and allow new ones
+        for (uint256 i = 0; i < govTokens.length; i++) {
+            address govTokenAddress = govTokens[i];
+            IERC20(govTokenAddress).safeApprove(converter, 0);
+            IERC20(govTokenAddress).safeApprove(_converter, type(uint256).max);
+        }
+
+        // Set new converter
+        converter = _converter;
+    }
+
     function getGovTokens() external view returns (address[] memory) {
         return govTokens;
     }

--- a/contracts/StrategyIdle.sol
+++ b/contracts/StrategyIdle.sol
@@ -249,7 +249,7 @@ contract StrategyIdle is BaseStrategyInitializable {
         _profit = _profit.add(liquidated);
 
         // Recalculate profit
-        wantBalance = want.balanceOf(address(this));
+        wantBalance = balanceOfWant();
 
         if (wantBalance < _profit) {
             _profit = wantBalance;

--- a/contracts/StrategyIdle.sol
+++ b/contracts/StrategyIdle.sol
@@ -324,20 +324,21 @@ contract StrategyIdle is BaseStrategyInitializable {
         updateVirtualPrice
         returns (uint256 _liquidatedAmount, uint256 _loss)
     {
-        if (balanceOfWant() < _amountNeeded) {
+        uint256 wantBalance = balanceOfWant();
+
+        if (wantBalance < _amountNeeded) {
             // Note: potential drift by 1 wei, reduce to max balance in the case approx is rounded up
-            uint256 amountToRedeem = _amountNeeded.sub(balanceOfWant());
+            uint256 amountToRedeem = _amountNeeded.sub(wantBalance);
             freeAmount(amountToRedeem);
+            wantBalance = balanceOfWant();
         }
 
         // _liquidatedAmount min(_amountNeeded, balanceOfWant), otw vault accounting breaks
-        uint256 balanceOfWant = balanceOfWant();
-
-        if (balanceOfWant >= _amountNeeded) {
+        if (wantBalance >= _amountNeeded) {
             _liquidatedAmount = _amountNeeded;
         } else {
-            _liquidatedAmount = balanceOfWant;
-            _loss = _amountNeeded.sub(balanceOfWant);
+            _liquidatedAmount = wantBalance;
+            _loss = _amountNeeded.sub(wantBalance);
         }
     }
 

--- a/contracts/StrategyIdle.sol
+++ b/contracts/StrategyIdle.sol
@@ -164,9 +164,8 @@ contract StrategyIdle is BaseStrategyInitializable {
     }
 
     function estimatedTotalAssets() public override view returns (uint256) {
-        // TODO: Build a more accurate estimate using the value of all positions in terms of `want`
         return want.balanceOf(address(this))
-                   .add(balanceOnIdle()) //TODO: estimate gov tokens value
+                   .add(balanceOnIdle())
         ;
     }
 
@@ -270,7 +269,6 @@ contract StrategyIdle is BaseStrategyInitializable {
      * be 0, and you should handle that scenario accordingly.
      */
     function adjustPosition(uint256 _debtOutstanding) internal override updateVirtualPrice {
-        // TODO: Do something to invest excess `want` tokens (from the Vault) into your positions
         // NOTE: Try to adjust positions so that `_debtOutstanding` can be freed up on *next* harvest (not immediately)
 
         //emergency exit is dealt with in prepareReturn
@@ -326,8 +324,6 @@ contract StrategyIdle is BaseStrategyInitializable {
         updateVirtualPrice
         returns (uint256 _liquidatedAmount, uint256 _loss)
     {
-        // TODO: Do stuff here to free up to `_amountNeeded` from all positions back into `want`
-
         if (balanceOfWant() < _amountNeeded) {
             // Note: potential drift by 1 wei, reduce to max balance in the case approx is rounded up
             uint256 amountToRedeem = _amountNeeded.sub(balanceOfWant());
@@ -352,7 +348,6 @@ contract StrategyIdle is BaseStrategyInitializable {
     }
 
     function prepareMigration(address _newStrategy) internal override {
-        // TODO: Transfer any non-`want` tokens to the new strategy
         // NOTE: `migrate` will automatically forward all `want` in this strategy to the new one
 
         // this automatically claims the gov tokens in addition to want

--- a/contracts/StrategyIdle.sol
+++ b/contracts/StrategyIdle.sol
@@ -453,6 +453,14 @@ contract StrategyIdle is BaseStrategyInitializable {
         converter = _converter;
     }
 
+    function disableConverter() external onlyKeepers {
+        // Disallow current converter
+        for (uint256 i = 0; i < govTokens.length; i++) {
+            address govTokenAddress = govTokens[i];
+            IERC20(govTokenAddress).safeApprove(converter, 0);
+        }
+    }
+
     function getGovTokens() external view returns (address[] memory) {
         return govTokens;
     }

--- a/interfaces/Balancer/IBPool.sol
+++ b/interfaces/Balancer/IBPool.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: AGPL-3.0
+
+pragma solidity ^0.6.12;
+
+interface IBPool {
+    function swapExactAmountIn(
+        address tokenIn,
+        uint tokenAmountIn,
+        address tokenOut,
+        uint minAmountOut,
+        uint maxPrice
+    )
+    external
+    returns (uint tokenAmountOut, uint spotPriceAfter);
+}

--- a/interfaces/IConverter.sol
+++ b/interfaces/IConverter.sol
@@ -1,0 +1,17 @@
+
+// SPDX-License-Identifier: AGPL-3.0
+
+pragma solidity ^0.6.6;
+
+interface IConverter {
+    function convert(
+        uint amountIn,
+        uint amountOutMin,
+        address assetIn,
+        address assetOut,
+        address to
+    ) external returns (uint256 convertedAmount);
+
+    function getAmountOut(uint256 amountIn, address assetIn, address assetOut) external view returns (uint256 amountOut);
+    function getAmountIn(uint256 amountOut, address assetIn, address assetOut) external view returns (uint256 amountIn);
+}

--- a/interfaces/Uniswap/IUniswapRouter.sol
+++ b/interfaces/Uniswap/IUniswapRouter.sol
@@ -13,4 +13,6 @@ interface IUniswapRouter {
     ) external returns (uint[] memory amounts);
 
     function getAmountsOut(uint256 amountIn, address[] memory path) external view returns (uint256[] memory amounts);
+
+    function getAmountsIn(uint256 amountOut, address[] memory path) external view returns (uint256[] memory amounts);
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,7 +91,7 @@ def aprDeposit(token):
 def tokenWhale(accounts, Contract, token):
     tokenWhalesAndQuantities = {
         "0x6B175474E89094C44Da98b954EedeAC495271d0F" : {
-            "whale" : "0x3f5CE5FBFe3E9af3971dD833D26bA9b5C936f0bE", # binance
+            "whale" : "0x40ec5b33f54e0e8a33a975908c5ba1c14e5bbbdf", # matic
             "quantity": 1 * 1e6,
         },
         "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51" : {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -204,39 +204,3 @@ def strategyFactory(strategist, keeper, proxyFactoryInitializable, idleToken, co
         strategy.setKeeper(keeper)
         return strategy
     yield factory
-
-@pytest.fixture(scope="session", autouse=True)
-def pre(request, interface, accounts, chain):
-    # test IIP7
-    print('BEFORE EVERYTHING')
-
-    proxyAdmin = interface.ProxyAdmin('0x7740792812A00510b50022D84e5c4AC390e01417')
-    newImplementation = "0x2854A270FE9c839ffE453e9178d1cFeF109d6B8E"
-
-    IdleDai = "0x3fE7940616e5Bc47b0775a0dccf6237893353bB4"
-    IdleUsdc = "0x5274891bEC421B39D23760c04A6755eCB444797C"
-    IdleUsdt = "0xF34842d05A1c888Ca02769A633DF37177415C2f8"
-    IdleWbtc = "0x8C81121B15197fA0eEaEE1DC75533419DcfD3151"
-    IdleWeth = "0xC8E6CA6E96a326dC448307A5fDE90a0b21fd7f80"
-
-    governance = interface.GovernorAlpha('0x2256b25CFC8E35c3135664FD03E77595042fe31B')
-    eta = governance.proposals(7).dict()['eta']
-    print ('Expected eta: ', eta)
-    currentTime = chain.time()
-    print ('Current Time: ', currentTime)
-
-
-    if (proxyAdmin.getProxyImplementation(IdleDai) != newImplementation):
-        print ('Time machine...')
-        chain.mine(1, eta+1)
-        currentTime = chain.time()
-        print ('Current Time: ', currentTime)
-        executor = accounts[0]
-
-        governance.execute(7, {'from': executor})
-
-    assert proxyAdmin.getProxyImplementation(IdleDai)  == newImplementation
-    assert proxyAdmin.getProxyImplementation(IdleUsdc) == newImplementation
-    assert proxyAdmin.getProxyImplementation(IdleUsdt) == newImplementation
-    assert proxyAdmin.getProxyImplementation(IdleWbtc) == newImplementation
-    assert proxyAdmin.getProxyImplementation(IdleWeth) == newImplementation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,11 +24,11 @@ def proxyFactoryInitializable(accounts, ProxyFactoryInitializable):
 @pytest.fixture(
     params=[
         "DAI",
-        #"SUSD",
-        #"USDC",
-        #"WBTC",
-        #"USDT",
-        #"TUSD",
+        "SUSD",
+        "USDC",
+        "WBTC",
+        "USDT",
+        "TUSD",
     ]
 )
 def token(Token, request):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,10 @@ def weth(Contract):
     yield Contract("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
 
 @pytest.fixture
+def bpool(Contract):
+    yield Contract("0xCaf467DFE064a1F54e4ece8515Ddf326B9bE801E")
+
+@pytest.fixture
 def idleToken(interface, token):
     idleTokens = {
         "0x6B175474E89094C44Da98b954EedeAC495271d0F" : "0x3fE7940616e5Bc47b0775a0dccf6237893353bB4",
@@ -140,10 +144,13 @@ def keeper(accounts):
     yield accounts[4]
 
 @pytest.fixture
-def converter(strategist, Converter, uniswap, weth):
+def converter(strategist, Converter, uniswap, weth, bpool, idle):
     yield Converter.deploy(
         uniswap,
         weth,
+        bpool,
+        idle,
+        "0.01 ether",
         {"from": strategist}
     )
 

--- a/tests/test_setters_getters.py
+++ b/tests/test_setters_getters.py
@@ -6,8 +6,8 @@ from brownie import config
 
 def test_constructor(vault, gov, strategy, strategist, comp, idle, token):
     assert strategy.name() == "StrategyIdleidle"+ token.symbol().upper() + "Yield"
-    assert strategy.govTokens(0) == comp
-    assert strategy.govTokens(1) == idle
+    assert strategy.getGovTokens()[0] == comp
+    assert strategy.getGovTokens()[1] == idle
 
 def test_incorrect_vault(pm, guardian, gov, strategist, rewards, strategyFactory, Token):
     token = guardian.deploy(Token)
@@ -78,7 +78,7 @@ def test_setters(vault, gov, strategy, token, tokenWhale, strategist, guardian):
 
     govTokens = [token.address]
     strategy.setGovTokens(govTokens, {"from": gov})
-    assert strategy.govTokens(0) == govTokens[0]
+    assert strategy.getGovTokens()[0] == govTokens[0]
 
     with brownie.reverts("!authorized"):
         strategy.setCheckVirtualPrice(False, {"from": strategist})

--- a/tests/test_setters_getters.py
+++ b/tests/test_setters_getters.py
@@ -80,7 +80,7 @@ def test_setters(vault, gov, strategy, token, tokenWhale, strategist, converter,
     strategy.setGovTokens(govTokens, {"from": gov})
     assert strategy.getGovTokens()[0] == govTokens[0]
 
-    strategy.setConverter(converter, {"from": guardian})
+    strategy.setConverter(converter, {"from": gov})
     assert strategy.getConverter() == converter
 
     with brownie.reverts("!authorized"):

--- a/tests/test_setters_getters.py
+++ b/tests/test_setters_getters.py
@@ -44,7 +44,7 @@ def test_double_init_no_proxy(strategyFactory, vault, strategist):
             strategist
         )
 
-def test_setters(vault, gov, strategy, token, tokenWhale, strategist, guardian):
+def test_setters(vault, gov, strategy, token, tokenWhale, strategist, converter, guardian):
     decimals = token.decimals()
     token.approve(vault, 2 ** 256 - 1, {"from": tokenWhale})
     vault.setDepositLimit(2 ** 256 - 1, {"from": gov})
@@ -80,8 +80,8 @@ def test_setters(vault, gov, strategy, token, tokenWhale, strategist, guardian):
     strategy.setGovTokens(govTokens, {"from": gov})
     assert strategy.getGovTokens()[0] == govTokens[0]
 
-    strategy.setConverter(token, {"from": guardian})
-    assert strategy.getConverter() == token
+    strategy.setConverter(converter, {"from": guardian})
+    assert strategy.getConverter() == converter
 
     with brownie.reverts("!authorized"):
         strategy.setCheckVirtualPrice(False, {"from": strategist})

--- a/tests/test_setters_getters.py
+++ b/tests/test_setters_getters.py
@@ -80,6 +80,9 @@ def test_setters(vault, gov, strategy, token, tokenWhale, strategist, guardian):
     strategy.setGovTokens(govTokens, {"from": gov})
     assert strategy.getGovTokens()[0] == govTokens[0]
 
+    strategy.setConverter(token, {"from": guardian})
+    assert strategy.getConverter() == token
+
     with brownie.reverts("!authorized"):
         strategy.setCheckVirtualPrice(False, {"from": strategist})
 
@@ -106,6 +109,9 @@ def test_setters(vault, gov, strategy, token, tokenWhale, strategist, guardian):
 
     with brownie.reverts("!authorized"):
         strategy.setGovTokens(govTokens, {"from": strategist})
+
+    with brownie.reverts("!authorized"):
+        strategy.setConverter(token, {"from": strategist})
 
     govTokens = [token.address]*(strategy.MAX_GOV_TOKENS_LENGTH() + 1)
     with brownie.reverts("GovTokens too long"):

--- a/tests/test_swapper.py
+++ b/tests/test_swapper.py
@@ -1,0 +1,79 @@
+import pytest
+import brownie
+from brownie import Wei
+from brownie import config
+
+
+def test_converter_balancer_weth(converter, accounts, idle, weth):
+    user = accounts[0]
+    idleWhale = accounts.at('0x107A369bc066c77FF061c7d2420618a6ce31B925', True)
+
+    amount = '100 ether'
+    idle.transfer(user, amount, {'from': idleWhale})
+
+    idle.approve(converter, amount, {'from': user})
+
+    balancePre = weth.balanceOf(user)
+    tx = converter.convert(amount, 1, idle, weth, user, {'from': user})
+
+    assert tx.events['LOG_SWAP']['tokenAmountIn'] == 100 * (10 ** 18)
+    assert tx.events['LOG_SWAP']['tokenAmountOut'] == (weth.balanceOf(user)-balancePre)
+
+    assert weth.balanceOf(converter) == 0
+    assert idle.balanceOf(converter) == 0
+
+    amount = '0.005 ether'
+    idle.transfer(user, amount, {'from': idleWhale})
+
+    idle.approve(converter, amount, {'from': user})
+
+    balancePre = weth.balanceOf(user)
+    tx = converter.convert(amount, 1, idle, weth, user, {'from': user})
+
+    assert tx.events.count('LOG_SWAP') == 0
+
+    assert tx.events['Swap']['amount0In'] == 5000000000000000
+    assert tx.events['Swap']['amount1Out'] == (weth.balanceOf(user)-balancePre)
+
+    assert weth.balanceOf(converter) == 0
+    assert idle.balanceOf(converter) == 0
+
+
+def test_converter_balancer_token(Contract, converter, accounts, idle, weth):
+    dai = Contract('0x6B175474E89094C44Da98b954EedeAC495271d0F')
+
+    user = accounts[0]
+    idleWhale = accounts.at('0x107A369bc066c77FF061c7d2420618a6ce31B925', True)
+
+    amount = '100 ether'
+    idle.transfer(user, amount, {'from': idleWhale})
+
+    idle.approve(converter, amount, {'from': user})
+
+    balancePre = dai.balanceOf(user)
+    tx = converter.convert(amount, 1, idle, dai, user, {'from': user})
+
+    assert tx.events['LOG_SWAP']['tokenAmountIn'] == 100 * (10 ** 18)
+    assert tx.events['LOG_SWAP']['tokenAmountOut'] == tx.events['Swap']['amount1In']
+    assert tx.events['Swap']['amount0Out'] == (dai.balanceOf(user)-balancePre)
+
+    assert weth.balanceOf(converter) == 0
+    assert idle.balanceOf(converter) == 0
+    assert dai.balanceOf(converter) == 0
+
+    amount = '0.005 ether'
+    idle.transfer(user, amount, {'from': idleWhale})
+
+    idle.approve(converter, amount, {'from': user})
+
+    balancePre = dai.balanceOf(user)
+    tx = converter.convert(amount, 1, idle, dai, user, {'from': user})
+
+    assert tx.events.count('LOG_SWAP') == 0
+
+    assert tx.events['Swap'][0]['amount0In'] == 5000000000000000
+    assert tx.events['Swap'][1]['amount0Out'] == (dai.balanceOf(user)-balancePre)
+
+    assert weth.balanceOf(converter) == 0
+    assert idle.balanceOf(converter) == 0
+    assert dai.balanceOf(converter) == 0


### PR DESCRIPTION
Needs:
- Idle started to incentivise liquidity on SushiSwap and opened a pool on Balancer. Current Uniswap liquidity is low and price is not good anymore, SushiSwap and Balancer are better. It affects yield generated for our users.
- Swap logic to want is currently embedded in the strategy (e.g. logic for stkAave to Want), any update requires a migration

Done:
- externalised swap logic in a Converter component which is upgradable by governance or management
- swap logic realise swap for Idle on Balancer to WETH (best liquidity) and to other assets (WETH to Want) via Uniswap like contract
- converter can be configured to swap on Sushi or Uniswap via governance and management action. Balancer pool can be change too by them.
- improved gas utilisation for some variables access